### PR TITLE
fix: fix git ignore src/main/java/com/asledgehammer/rosetta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ dist
 bin
 **/.DS_Store
 docs/
-rosetta/
+/rosetta/
 dist2/


### PR DESCRIPTION
Fix problem: `.gitignore` `rosetta/` rule ignore the `rosetta` dir in `src`.
After pulling the project, running it will report an error of 'RosettaUtils not found'.
Now you can resubmit to resolve the issue with the report 'RosettaUtils not found'.