### PR TITLE
Fix incorrect indexing of output path argument

### DIFF
--- a/src/main/java/com/asledgehammer/candle/Candle.java
+++ b/src/main/java/com/asledgehammer/candle/Candle.java
@@ -86,7 +86,7 @@ class Candle {
 
   private static void mainRosetta(String[] yargs) throws IOException {
     String path = "./dist/";
-    if (yargs.length != 0) path = yargs[1];
+    if (yargs.length != 0) path = yargs[0];
 
     File dir = new File(path);
     if (!dir.exists() && !dir.mkdirs()) throw new IOException("Failed to mkdirs: " + path);
@@ -102,7 +102,7 @@ class Candle {
 
   private static void mainLua(String[] yargs) throws IOException {
     String path = "./dist/";
-    if (yargs.length != 0) path = yargs[1];
+    if (yargs.length != 0) path = yargs[0];
 
     File dir = new File(path);
     if (!dir.exists() && !dir.mkdirs()) throw new IOException("Failed to mkdirs: " + path);

--- a/src/main/java/com/asledgehammer/candle/LuaWizard.java
+++ b/src/main/java/com/asledgehammer/candle/LuaWizard.java
@@ -11,7 +11,7 @@ public class LuaWizard {
     public static void main(String[] yargs) throws IOException {
 
         String path = "./dist/";
-        if (yargs.length != 0) path = yargs[1];
+        if (yargs.length != 0) path = yargs[0];
 
         File dir = new File(path);
         if (!dir.exists() && !dir.mkdirs()) throw new IOException("Failed to mkdirs: " + path);


### PR DESCRIPTION
Fixes an exception that occurs when passing the output path argument - index 1 was being checked instead of index 0 in the arguments array. Also adds a workaround for when java method names/argument names are not valid Lua identifiers, as a new class in B42 does define methods with these names, preventing me from running Stylua which is a requirement for addon manager addons.