### PR TITLE
Add Rosetta path argument

### DIFF
--- a/src/main/java/com/asledgehammer/candle/Candle.java
+++ b/src/main/java/com/asledgehammer/candle/Candle.java
@@ -5,9 +5,6 @@ import com.asledgehammer.candle.impl.PythonBag;
 import com.asledgehammer.candle.impl.PythonTypingsRenderer;
 import com.asledgehammer.candle.impl.RosettaRenderer;
 import zombie.Lua.LuaManager;
-import zombie.core.skinnedmodel.runtime.*;
-import zombie.input.JoypadManager;
-import zombie.iso.objects.interfaces.Thumpable;
 
 import java.io.File;
 import java.io.IOException;
@@ -98,14 +95,17 @@ class Candle {
   }
 
   private static void mainLua(String[] yargs) throws IOException {
+    // any more arguments and this should probably be replaced with 'proper' handling
     String path = "./dist/";
     if (yargs.length != 0) path = yargs[0];
+    String rosettaPath = "./rosetta/json/";
+    if (yargs.length > 1) rosettaPath = yargs[1];
 
     File dir = new File(path);
     if (!dir.exists() && !dir.mkdirs()) throw new IOException("Failed to mkdirs: " + path);
 
     Candle candle = new Candle();
-    candle.graph.walkLegacy();
+    candle.graph.walkLegacy(rosettaPath);
 
     // Export to Lua
     candle.render(new EmmyLuaRenderer());

--- a/src/main/java/com/asledgehammer/candle/CandleGraph.java
+++ b/src/main/java/com/asledgehammer/candle/CandleGraph.java
@@ -2,7 +2,6 @@ package com.asledgehammer.candle;
 
 import com.asledgehammer.rosetta.Rosetta;
 import com.google.common.reflect.ClassPath;
-import zombie.input.JoypadManager;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -83,9 +82,9 @@ public class CandleGraph {
     }
   }
 
-  public void walkLegacy() {
+  public void walkLegacy(String rosettaPath) {
     try {
-      docs.addDirectory(new File("./rosetta/json/"));
+      docs.addDirectory(new File(rosettaPath));
     } catch (Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
Adds a second argument to specify the directory Rosetta data is contained in, instead of the current hardcoded path. The argument is optional and defaults to the original value.

If any further arguments are added, a formal argument parsing library should probably be introduced. However, for now both arguments are simply positional.