### PR TITLE
Rewrite exposed class detection using bytecode analysis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,5 +46,5 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.0'
 // https://mvnrepository.com/artifact/org.jsoup/jsoup
     implementation 'org.jsoup:jsoup:1.16.1'
-    implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.26.3'
+    implementation 'org.ow2.asm:asm:9.8'
 }


### PR DESCRIPTION
Replaces the exposed class detection added in my previous PR #14 with a method that analyses the exposer's bytecode rather than its source code. The rationale for this is simple: this was the only reason Umbrella needed any Java source code, and decompilation alone takes the vast majority of Umbrella's build time. The newer code is also much cleaner/shorter, and is resilient to the possibility of a future version's Exposer having unrecoverable decompilation errors. It also cleans up what I feel is a usability issue introduced by my previous PR where Candle Compiler was dependent on a provided `LuaManager.java` file.

As a result, this PR removes the dependency on javaparser, and adds a dependency on ow2-asm.