### PR TITLE
Add classes exposed by other methods to graph

### DIFF
--- a/src/main/java/com/asledgehammer/candle/Candle.java
+++ b/src/main/java/com/asledgehammer/candle/Candle.java
@@ -96,7 +96,7 @@ class Candle {
     RosettaRenderer renderer = new RosettaRenderer();
     candle.render(renderer);
     renderer.saveJSON(candle.graph, new File("./dist2/json/"));
-    renderer.saveYAML(candle.graph, new File("./dist2/yml/"));
+    renderer.saveYAML(candle.graph, Path.of("./dist2/yml/"));
   }
 
   private static void mainLua(String[] yargs) throws IOException {

--- a/src/main/java/com/asledgehammer/candle/CandleClassBag.java
+++ b/src/main/java/com/asledgehammer/candle/CandleClassBag.java
@@ -24,26 +24,31 @@ public class CandleClassBag {
 
   private void addClassesFromJar(Path jar) {
     try (FileSystem gameJar = FileSystems.newFileSystem(jar)) {
-      Path exposerPath = gameJar.getPath("zombie", "Lua", "LuaManager$Exposer.class");
-      if (!Files.exists(exposerPath) || !Files.isRegularFile(exposerPath)) {
-        return;
-      }
+      Set<String> visitedClasses = new HashSet<>();
+      Stack<String> classStack = new Stack<>();
+      classStack.push("zombie/Lua/LuaManager$Exposer");
 
-      ClassReader reader = new ClassReader(
-              Files.newInputStream(exposerPath)
-      );
-      reader.accept(new ClassVisitor(Opcodes.ASM9) {
-        @Override
-        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
-          if (name.equals("exposeAll")) {
-            return new ExposeMethodVisitor(
-                    api,
-                    super.visitMethod(access, name, descriptor, signature, exceptions)
-            );
-          }
-          return super.visitMethod(access, name, descriptor, signature, exceptions);
+      while (!classStack.empty()) {
+        String clazz = classStack.pop();
+        Path clazzPath = gameJar.getPath(clazz + ".class");
+        if (!Files.exists(clazzPath) || !Files.isRegularFile(clazzPath)) {
+          continue;
         }
-      }, 0);
+
+        ClassReader reader = new ClassReader(
+                Files.newInputStream(clazzPath)
+        );
+        ExposeClassVisitor visitor = new ExposeClassVisitor(
+                clazz.equals("zombie/Lua/LuaManager$Exposer") ? "exposeAll" : "setExposed"
+        );
+        reader.accept(visitor, 0);
+
+        visitedClasses.add(clazz);
+
+        visitor.discoveredExposerMethods.stream()
+                                        .filter((_clazz) -> !visitedClasses.contains(_clazz))
+                                        .forEach(classStack::push);
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -104,39 +109,64 @@ public class CandleClassBag {
         | clazz == KahluaTable.class;
   }
 
-  /// Method visitor that exposes classes exposed by the method.
-  private class ExposeMethodVisitor extends MethodVisitor {
-    protected ExposeMethodVisitor(int api, MethodVisitor methodVisitor) {
-      super(api, methodVisitor);
+  private class ExposeClassVisitor extends ClassVisitor {
+    private final List<String> discoveredExposerMethods = new ArrayList<>();
+    private final String target;
+
+    public ExposeClassVisitor(String target) {
+      super(Opcodes.ASM9);
+      this.target = target;
     }
 
-    /// The class on the top of the stack.
-    Type topClass = null;
-
     @Override
-    public void visitLdcInsn(Object value) {
-      if (value instanceof Type type) {
-        // this makes the assumption that any class pushed will not be removed before the next call to setExposed
-        // even though this is dumb, in practice for this limited usage it seems reliable
-        // there isn't any need to do anything else with class objects in that method
-        topClass = type;
+    public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+      if (name.equals(target)) {
+        return new ExposeMethodVisitor(
+                api,
+                super.visitMethod(access, name, descriptor, signature, exceptions)
+        );
       }
-      super.visitLdcInsn(value);
+      return super.visitMethod(access, name, descriptor, signature, exceptions);
     }
 
-    @Override
-    public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
-      if (owner.equals("zombie/Lua/LuaManager$Exposer") && name.equals("setExposed")) {
-        assert topClass != null;
-        try {
-          Class<?> exposedClazz = Class.forName(topClass.getClassName(), false, this.getClass().getClassLoader());
-          addClass(exposedClazz);
-          topClass = null;
-        } catch(ClassNotFoundException exception) {
-          System.out.println("Cannot find exposed type " + topClass.getClassName());
+    /// Method visitor that exposes classes exposed by the method.
+    private class ExposeMethodVisitor extends MethodVisitor {
+      protected ExposeMethodVisitor(int api, MethodVisitor methodVisitor) {
+        super(api, methodVisitor);
+      }
+
+      /// The class on the top of the stack.
+      Type topClass = null;
+
+      @Override
+      public void visitLdcInsn(Object value) {
+        if (value instanceof Type type) {
+          // this makes the assumption that any class pushed will not be removed before the next call to setExposed
+          // even though this is dumb, in practice for this limited usage it seems reliable
+          // there isn't any need to do anything else with class objects in that method
+          topClass = type;
+        }
+        super.visitLdcInsn(value);
+      }
+
+      @Override
+      public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+        if (name.equals("setExposed")) {
+          if (owner.equals("zombie/Lua/LuaManager$Exposer")) {
+            assert topClass != null;
+            try {
+              Class<?> exposedClazz = Class.forName(topClass.getClassName(), false, this.getClass().getClassLoader());
+              addClass(exposedClazz);
+              topClass = null;
+            } catch (ClassNotFoundException exception) {
+              System.out.println("Cannot find exposed type " + topClass.getClassName());
+            }
+          } else {
+            discoveredExposerMethods.add(owner);
+          }
+          super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
         }
       }
-      super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
     }
   }
 }

--- a/src/main/java/com/asledgehammer/candle/CandleGraph.java
+++ b/src/main/java/com/asledgehammer/candle/CandleGraph.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
 
@@ -203,7 +204,7 @@ public class CandleGraph {
 
   public static void write(File file, String content) {
     try {
-      FileWriter writer = new FileWriter(file);
+      FileWriter writer = new FileWriter(file, StandardCharsets.UTF_8);
       writer.write(content);
       writer.flush();
       writer.close();


### PR DESCRIPTION
Adds classes to the graph that are exposed by other methods called by `LuaManager.Exposer.exposeAll` as it is becoming a pattern for TIS to expose groups of related classes in a `setExposed` method belonging to another class rather than directly in `exposeAll` like most others. This was a known hole in our coverage as the world map API is exposed this way.

Additionally:
- Fixes an uncommitted single line change from my previous PR resulting in the program being uncompilable.
- Ensures the output is written as UTF-8, as it was causing issues for Stylua. (it is not clear why this wasn't a problem until now)